### PR TITLE
Skip a trailing colon after the URL to a PR

### DIFF
--- a/AWS/Lambda/PREmailer/pr_emailer.py
+++ b/AWS/Lambda/PREmailer/pr_emailer.py
@@ -102,7 +102,7 @@ def get_synchronize_email_body(event, patch):
     pr_number = event_get_pr_number(event)
 
     return f"""
-https://github.com/{user} updated {pr_html}:
+https://github.com/{user} updated {pr_html}
 
 {patch}
 """
@@ -113,7 +113,7 @@ def get_open_email_body(event, patch):
     pr_body = event['pull_request']['body']
 
     return f"""
-https://github.com/{user} created {pr_html}:
+https://github.com/{user} created {pr_html}
 
 {pr_body}
 


### PR DESCRIPTION
When the plain (non-hyperlink) URL is followed by a colon (in a plaintext email), the trailing colon is treated as part of the url; at least Alpine for text based emails, and Apple Mail for GUI clients, treat the colon as part of the URL here. This means that following the URL fails unless manual effort is made to remove the colon.