### PR TITLE
Ignore merge commits in PR Emailer

### DIFF
--- a/AWS/Lambda/PREmailer/pr_emailer.py
+++ b/AWS/Lambda/PREmailer/pr_emailer.py
@@ -385,6 +385,10 @@ def lambda_handler(event, context):
     project_list = set()
     gh_pr = gh.get_repo('llvm/llvm-project').get_issue(pr_number).as_pull_request()
     for commit in gh_pr.get_commits():
+        if len(commit.parents) > 1:
+            # Ignore merge commits, they will show files changed on main
+            # unrelated to this PR.
+            continue
         project_list.update(create_project_list([f.filename for f in commit.files], project_path_email))
 
     # Iterate through the list of projects and cross-post if necessary


### PR DESCRIPTION
When merging main into a PR, the merge commits bring in changes to files in all subprojects. Essentially this means that any PR that merges main ends up sending mails to all mailing lists.

When iterating over the commits in the PR, skip the merge commits. If the merge commits contains functional changes other than the pure merge, the same changed files should be present in other commits anyway, if the changes are due to conflicts.