### PR TITLE
Print the subject project tags in a deterministic order

### DIFF
--- a/AWS/Lambda/PREmailer/pr_emailer.py
+++ b/AWS/Lambda/PREmailer/pr_emailer.py
@@ -398,7 +398,7 @@ def lambda_handler(event, context):
     if 'MAIL_TO' in os.environ:
         mail_to = os.environ.get('MAIL_TO')
     # Setup the mail Subject
-    subject_tag = ' '.join(['[{}]'.format(p) for p in project_list])
+    subject_tag = ' '.join(['[{}]'.format(p) for p in sorted(project_list)])
     subject = f"{subject_tag} {pr_title} (PR #{pr_number})"
 
     # validate cors access


### PR DESCRIPTION
Currently they are in an unspecified order, which means that for one chain of mails, each mail may contain the tags in a different order. Sort them, to keep the order deterministic.